### PR TITLE
Updated metadata.json so it works with Gnome 3.20

### DIFF
--- a/Random_Walls@Antares/metadata.json
+++ b/Random_Walls@Antares/metadata.json
@@ -1,5 +1,5 @@
 {
-"shell-version": ["3.14","3.16","3.18"],
+"shell-version": ["3.14","3.16","3.18","3.20"],
 "uuid": "Random_Walls@Antares",
 "url": "https://github.com/rodakorn/randwall",
 "settings-schema": "org.gnome.shell.extensions.randwall",


### PR DESCRIPTION
I have the plugin installed and currently running it on my Gnome 3.20 setup. 

So far it still works as it did with Gnome 3.18.